### PR TITLE
Autorespond flag for CLI & connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ Usage: anyconnect connect [OPTIONS] URL
   Endpoint address
 
 Options:
-  -u, --user TEXT      Give username instead of KeePass lookup
-  -p, --password TEXT  Give password instead of KeePass lookup
-  --help               Show this message and exit.
+  -u, --user TEXT                 Give username instead of KeePass lookup
+  -p, --password TEXT             Give password instead of KeePass lookup
+  --autorespond / --noautorespond
+                                  Defines whether connect will automatically
+                                  respond to login banners
+
+  --help                          Show this message and exit.
 ```
 
 # Examples

--- a/cisco_anyconnect_cli/cisco_anyconnect.py
+++ b/cisco_anyconnect_cli/cisco_anyconnect.py
@@ -12,11 +12,12 @@ class CiscoAnyConnect:
         self.bin = self.detect_binary()
         logging.info(f"Using {self.bin}")
 
-    def connect(self, url: str, user: str, password: str):
+    def connect(self, url: str, user: str, password: str, autorespond: bool = False):
         logging.info(f"Connecting to '{url}' as '{user}'")
         proc = Popen([self.bin, "connect", url, "-s"], stdout=PIPE, stdin=PIPE, stderr=STDOUT)
 
-        stdout = proc.communicate(input=f"{user}\n{password}\n".encode())[0]
+        answer = "y\n" if autorespond else ""
+        stdout = proc.communicate(input=f"{user}\n{password}\n{answer}".encode())[0]
         logging.debug(stdout.decode())
         proc.wait()
 

--- a/cisco_anyconnect_cli/cli.py
+++ b/cisco_anyconnect_cli/cli.py
@@ -33,8 +33,13 @@ def main(ctx, path):
 @click.argument("url")
 @click.option("-u", "--user", help="Give username instead of KeePass lookup")
 @click.option("-p", "--password", help="Give password instead of KeePass lookup")
+@click.option(
+    "--autorespond/--noautorespond",
+    default=False,
+    help="Defines whether connect will automatically respond to login banners"
+)
 @click.pass_context
-def connect(ctx, url, user, password):
+def connect(ctx, url, user, password, autorespond):
     try:
         if user is None:
             creds = get_credentials(url)
@@ -42,7 +47,7 @@ def connect(ctx, url, user, password):
             password = creds.password
 
         client = CiscoAnyConnect(ctx.obj)
-        client.connect(url, user, password)
+        client.connect(url, user, password, autorespond)
         sys.exit(0)
     except Exception as e:
         logging.error(e)


### PR DESCRIPTION
Some servers require the user to respond to a so-called banner upon login. Not providing an answer results in the login attempt failing. To facilitate automating logging into such servers the --autorespond flag will automatically respond 'yes' to a login banner. This flag defaults to false and supports the complementary --noautorespond flag should the default ever change.